### PR TITLE
fix typo in git-url for Package.swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add LingoProvider as a dependancy in your `Package.swift` file:
 ```swift
 dependencies: [
 	...,
-	.Package(url: "https://github.com/vapor-comunity/lingo-provider.git", majorVersion: 1)]
+	.Package(url: "https://github.com/vapor-community/lingo-provider.git", majorVersion: 1)]
 ]
 ```
 


### PR DESCRIPTION
If you would just copy and paste fetching the repo isn't working and causes confusing due to typo :)