### PR TITLE
Add locale convenience to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ let lingo = try someContainer.make(Lingo.self)
 let localizedTitle = lingo.localize("welcome.title", locale: "en")
 ```
 
+To get the locale of a user out of the request, you can use `request.locale`. This uses a language, which is in the HTTP header and which is in your available locales, if that exists. Otherwise it falls back to the default locale. Now you can use different locales dynamically:
+
+```swift
+let localizedTitle = lingo.localize("welcome.title", locale: request.locale)
+```
+
+When overwriting the requested locale, just write the new locale into the session, e.g. like that:
+
+```swift
+if let session = try? session() {
+    session["locale"] = locale
+}
+```
+
 Use the following syntax for defining localizations in a JSON file:
 
 ```swift

--- a/Sources/Request+Locale.swift
+++ b/Sources/Request+Locale.swift
@@ -1,0 +1,45 @@
+import Vapor
+import Lingo
+
+extension Request {
+    var locale: String {
+        if let session = try? session(), let sessionlocale = session["locale"] {
+            return sessionlocale
+        } else {
+            // Parse locale, ordered from general case to special case
+            // If nothing helps.. use "en"
+            var locale: LocaleIdentifier = "en"
+            
+            // If Lingo has defaultLocale, use that
+            if let lingo = try? make(Lingo.self) {
+                locale = lingo.defaultLocale
+            
+                // If headers provide information, use those
+                if var langHeader = http.headers.firstValue(name: .acceptLanguage) {
+                    langHeader = langHeader.components(separatedBy: .whitespaces).joined()
+                    let langValues = langHeader.components(separatedBy: ",").map { HeaderValue.parse($0) ?? HeaderValue($0, parameters: ["q":"0"]) }
+                    let availableLocales = (try? lingo.dataSource.availableLocales()) ?? [locale]
+                    var localeWeight = 0.0
+                    for lang in langValues {
+                        let q = Double(lang.parameters["q"] ?? "1") ?? 1
+                        if localeWeight < q {
+                            if availableLocales.contains(lang.value) {
+                                localeWeight = q
+                                locale = lang.value
+                            } else if let baseLang = lang.value.split(separator: "-").first, availableLocales.contains(String(baseLang)) {
+                                localeWeight = q-0.01
+                                locale = String(baseLang)
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // Save locale into session and return
+            if let session = try? session() {
+                session["locale"] = locale
+            }
+            return locale
+        }
+    }
+}

--- a/Sources/Request+Locale.swift
+++ b/Sources/Request+Locale.swift
@@ -5,41 +5,36 @@ extension Request {
     var locale: String {
         if let session = try? session(), let sessionlocale = session["locale"] {
             return sessionlocale
-        } else {
-            // Parse locale, ordered from general case to special case
-            // If nothing helps.. use "en"
-            var locale: LocaleIdentifier = "en"
-            
-            // If Lingo has defaultLocale, use that
-            if let lingo = try? make(Lingo.self) {
-                locale = lingo.defaultLocale
-            
-                // If headers provide information, use those
-                if var langHeader = http.headers.firstValue(name: .acceptLanguage) {
-                    langHeader = langHeader.components(separatedBy: .whitespaces).joined()
-                    let langValues = langHeader.components(separatedBy: ",").map { HeaderValue.parse($0) ?? HeaderValue($0, parameters: ["q":"0"]) }
-                    let availableLocales = (try? lingo.dataSource.availableLocales()) ?? [locale]
-                    var localeWeight = 0.0
-                    for lang in langValues {
-                        let q = Double(lang.parameters["q"] ?? "1") ?? 1
-                        if localeWeight < q {
-                            if availableLocales.contains(lang.value) {
-                                localeWeight = q
-                                locale = lang.value
-                            } else if let baseLang = lang.value.split(separator: "-").first, availableLocales.contains(String(baseLang)) {
-                                localeWeight = q-0.01
-                                locale = String(baseLang)
-                            }
+        }
+        // Parse locale, ordered from general case to special case
+        // If nothing helps.. use "en"
+        var locale: LocaleIdentifier = "en"
+
+        // If Lingo has defaultLocale, use that
+        if let lingo = try? make(Lingo.self) {
+            locale = lingo.defaultLocale
+
+            // If headers provide information, use those
+            if var langHeader = http.headers.firstValue(name: .acceptLanguage) {
+                langHeader = langHeader.components(separatedBy: .whitespaces).joined()
+                let langValues = langHeader.components(separatedBy: ",").map { HeaderValue.parse($0) ?? HeaderValue($0, parameters: ["q":"0"]) }
+                let availableLocales = (try? lingo.dataSource.availableLocales()) ?? [locale]
+                var localeWeight = 0.0
+                for lang in langValues {
+                    let q = Double(lang.parameters["q"] ?? "1") ?? 1
+                    if localeWeight < q {
+                        if availableLocales.contains(lang.value) {
+                            localeWeight = q
+                            locale = lang.value
+                        } else if let baseLang = lang.value.split(separator: "-").first, availableLocales.contains(String(baseLang)) {
+                            localeWeight = q-0.01
+                            locale = String(baseLang)
                         }
                     }
                 }
             }
-            
-            // Save locale into session and return
-            if let session = try? session() {
-                session["locale"] = locale
-            }
-            return locale
         }
+
+        return locale
     }
 }


### PR DESCRIPTION
When using Lingo provider for a website, it might be convenient, to get the locale out of the session (if available) or out of the HTTP headers. That's what I implemented. (Since the HTTP header is quite complicated, the code is quite long, maybe someone has a better solution.)

Most prioritized is the locale in a session, afterwards the HTTP header is checked. If that fails, the Lingo defaultLocale is used. The last fallback is "en".

When this is merged, you can get the locale of the user by using `request.locale`, so when you want to get a localized message inside a controller, you could do the following: 

    if let lingo = try? request.make(Lingo.self) {
        let localizedString = lingo.localize("key", locale: request.locale)
    }