### PR TITLE
Custom workdir fix

### DIFF
--- a/Sources/LingoProvider.swift
+++ b/Sources/LingoProvider.swift
@@ -24,7 +24,8 @@ public struct LingoProvider: Vapor.Provider {
     public func register(_ services: inout Services) throws {
         services.register(Lingo.self) { (container) -> (Lingo) in
             let dirConfig = try container.make(DirectoryConfig.self)
-            let rootPath = dirConfig.workDir + self.localizationsDir
+            let workDir = dirConfig.workDir.hasSuffix("/") ? dirConfig.workDir : dirConfig.workDir + "/"
+            let rootPath = workDir + self.localizationsDir
             return try Lingo(rootPath: rootPath, defaultLocale: self.defaultLocale)
         }
     }

--- a/Sources/LingoProvider.swift
+++ b/Sources/LingoProvider.swift
@@ -14,16 +14,18 @@ extension Container {
 public struct LingoProvider: Vapor.Provider {
     
     let defaultLocale: String
-    let rootPath: String
+    let localizationsDir: String
     
     public init(defaultLocale: String, localizationsDir: String = "Localizations") {
         self.defaultLocale = defaultLocale
-        self.rootPath = DirectoryConfig.detect().workDir + localizationsDir
+        self.localizationsDir = localizationsDir
     }
     
     public func register(_ services: inout Services) throws {
         services.register(Lingo.self) { (container) -> (Lingo) in
-            return try Lingo(rootPath: self.rootPath, defaultLocale: self.defaultLocale)
+            let dirConfig = container.make(DirectoryConfig.self)
+            let rootPath = dirConfig.workDir + self.localizationsDir
+            return try Lingo(rootPath: rootPath, defaultLocale: self.defaultLocale)
         }
     }
     

--- a/Sources/LingoProvider.swift
+++ b/Sources/LingoProvider.swift
@@ -23,7 +23,7 @@ public struct LingoProvider: Vapor.Provider {
     
     public func register(_ services: inout Services) throws {
         services.register(Lingo.self) { (container) -> (Lingo) in
-            let dirConfig = container.make(DirectoryConfig.self)
+            let dirConfig = try container.make(DirectoryConfig.self)
             let rootPath = dirConfig.workDir + self.localizationsDir
             return try Lingo(rootPath: rootPath, defaultLocale: self.defaultLocale)
         }


### PR DESCRIPTION
By using the `detect()` method of `DirectoryConfig` to find the working directory instead of a `DirectoryConfig` service instance `workDir` property, we cannot support users with custom work directories as is intended to be supported by the `DirectoryConfig` service.

This wasn't a big deal before, but the `detect()` method is currently broken on xcode 11 beta and the workaround is to set a custom work directory.