### PR TITLE
LingoVaporLeaf as an available product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
        .macOS(.v10_15)
     ],
     products: [
-        .library(name: "LingoVapor", targets: ["LingoVapor"])
+        .library(name: "LingoVapor", targets: ["LingoVapor"]),
+        .library(name: "LingoVaporLeaf", targets: ["LingoVaporLeaf"])
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.27.0"),


### PR DESCRIPTION
I forgot this change. Without this, the `LingoVaporLeaf` target cannot be used when importing the package in the `Package.swift`. See this example:

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/30439790/163831596-800840c2-798f-49aa-8312-fb7b5c0e66a6.png">

