### PR TITLE
Adding some tags and middleware (mainly for SEO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ app.leaf.tags["localeLinks"] = LocaleLinksTag()
 
 Afterwards you can call them inside the Leaf templates:
 
-```
+```html
 <!-- String localization -->
 #localize("thisisthelingokey")
 #localize("lingokeywithvariable", "{\"foo\":\"bar\"}")

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ public func configure(_ app: Application) throws {
 
 ## Use
 
-After you have configured the provider, you can use  `lingoVapor` service to create `Lingo`:
+After you have configured the provider, you can use `lingoVapor` service to create `Lingo`:
 
 ```swift
 let lingo = try app.lingoVapor.lingo()
@@ -77,9 +77,32 @@ Use the following syntax for defining localizations in a JSON file:
 }
 ```
 
+### Locale redirection middleware
+
+In case you want to serv different locales on different subfolders, you can use the `LocaleRedirectMiddelware`.
+
+Add in `configure.swift`:
+```swift
+import LingoVapor
+
+// Inside `configure(_ app: Application)`:
+app.middleware.use(LocaleRedirectMiddelware())
+```
+
+Add in `routes.swift`:
+```swift
+import LingoVapor
+
+// Inside `routes(_ app: Application)`:
+app.get("home") { /* ... */ }
+app.get(":locale", "home") { /* ... */ } // For each route, add the one prefixed by the `locale` parameter
+```
+
+That way, going to `/home/` will redirect you to `/<locale>/home/` (with `<locale>` corresponding to your browser locale), and going to `/fr/home/` will display homepage in french whatever the browser locale is.
+
 ### Inside Leaf templates
 
-When using [Leaf](https://github.com/vapor/leaf) as templating engine, you can use `LocalizeTag` from `LingoVaporLeaf` for localization inside the templates.
+When using [Leaf](https://github.com/vapor/leaf) as templating engine, you can use `LocalizeTag`, `LocaleTag` and `LocaleLinksTag` from `LingoVaporLeaf` for localization inside the templates.
 
 Add in `configure.swift`:
 ```swift
@@ -87,13 +110,22 @@ import LingoVaporLeaf
 
 // Inside `configure(_ app: Application)`:
 app.leaf.tags["localize"] = LocalizeTag()
+app.leaf.tags["locale"] = LocaleTag()
+app.leaf.tags["localeLinks"] = LocaleLinksTag()
 ```
 
-Afterwards you can call it inside the Leaf templates:
+Afterwards you can call them inside the Leaf templates:
 
 ```
+<!-- String localization -->
 #localize("thisisthelingokey")
 #localize("lingokeywithvariable", "{\"foo\":\"bar\"}")
+
+<!-- Get current locale -->
+<html lang="#locale()">
+
+<!-- Generate link canonical and alternate tags -->
+#localeLinks("http://example.com/", "/canonical/path/")
 ```
 
 ## Learn more

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ Use the following syntax for defining localizations in a JSON file:
 
 ### Locale redirection middleware
 
-In case you want to serv different locales on different subfolders, you can use the `LocaleRedirectMiddelware`.
+In case you want to serv different locales on different subfolders, you can use the `LocaleRedirectMiddleware`.
 
 Add in `configure.swift`:
 ```swift
 import LingoVapor
 
 // Inside `configure(_ app: Application)`:
-app.middleware.use(LocaleRedirectMiddelware())
+app.middleware.use(LocaleRedirectMiddleware())
 ```
 
 Add in `routes.swift`:

--- a/Sources/LingoVapor/LocaleRedirectMiddelware.swift
+++ b/Sources/LingoVapor/LocaleRedirectMiddelware.swift
@@ -1,0 +1,30 @@
+import Vapor
+
+public final class LocaleRedirectMiddelware: Middleware {
+    public init() {}
+    public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        // Check if a language is passed in url
+        guard let lang = request.parameters.get("locale")
+        else {
+            // Redirect corresponding to specified locale
+            // For example, `/home/` will redirect to `/<request.locale>/home/`
+            return request.eventLoop.makeSucceededFuture(
+                request.redirect(to: "/\(request.locale)\(request.url.path)")
+            )
+        }
+        
+        // Get Lingo instance
+        guard let lingo = try? request.application.lingoVapor.lingo(),
+              let locales = try? lingo.dataSource.availableLocales()
+        else {
+            return request.eventLoop.makeFailedFuture(Abort(
+                .internalServerError, reason: "Unable to get Lingo instance"
+            ))
+        }
+        
+        // Set request locale from url
+        // For example, `/fr/home/` will display homepage in French
+        request.session.data["locale"] = locales.contains(lang) ? lang : lingo.defaultLocale
+        return next.respond(to: request)
+    }
+}

--- a/Sources/LingoVapor/LocaleRedirectMiddleware.swift
+++ b/Sources/LingoVapor/LocaleRedirectMiddleware.swift
@@ -1,6 +1,6 @@
 import Vapor
 
-public final class LocaleRedirectMiddelware: Middleware {
+public final class LocaleRedirectMiddleware: Middleware {
     public init() {}
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // Check if a language is passed in url

--- a/Sources/LingoVapor/LocaleRedirectMiddleware.swift
+++ b/Sources/LingoVapor/LocaleRedirectMiddleware.swift
@@ -4,7 +4,7 @@ public final class LocaleRedirectMiddleware: Middleware {
     public init() {}
     public func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
         // Check if a language is passed in url
-        guard let lang = request.parameters.get("locale")
+        guard let locale = request.parameters.get("locale")
         else {
             // Redirect corresponding to specified locale
             // For example, `/home/` will redirect to `/<request.locale>/home/`
@@ -22,9 +22,15 @@ public final class LocaleRedirectMiddleware: Middleware {
             ))
         }
         
+        // Check that the locale is available, else it's a 404
+        guard locales.contains(locale)
+        else {
+            return request.eventLoop.makeFailedFuture(Abort(.notFound))
+        }
+        
         // Set request locale from url
         // For example, `/fr/home/` will display homepage in French
-        request.session.data["locale"] = locales.contains(lang) ? lang : lingo.defaultLocale
+        request.session.data["locale"] = locale
         return next.respond(to: request)
     }
 }

--- a/Sources/LingoVaporLeaf/LocaleLinksTag.swift
+++ b/Sources/LingoVaporLeaf/LocaleLinksTag.swift
@@ -2,7 +2,7 @@ import Vapor
 import Leaf
 import LingoVapor
 
-public final class LangLinksTag: UnsafeUnescapedLeafTag {
+public final class LocaleLinksTag: UnsafeUnescapedLeafTag {
     public init() {}
     public func render(_ tag: LeafContext) throws -> LeafData {
         guard let lingo = try tag.application?.lingoVapor.lingo()

--- a/Sources/LingoVaporLeaf/LocaleLinksTag.swift
+++ b/Sources/LingoVaporLeaf/LocaleLinksTag.swift
@@ -1,0 +1,29 @@
+import Vapor
+import Leaf
+import LingoVapor
+
+public final class LangLinksTag: UnsafeUnescapedLeafTag {
+    public init() {}
+    public func render(_ tag: LeafContext) throws -> LeafData {
+        guard let lingo = try tag.application?.lingoVapor.lingo()
+        else {
+            throw Abort(.internalServerError, reason: "Unable to get Lingo instance")
+        }
+        let locale = tag.request?.locale ?? lingo.defaultLocale
+        
+        guard tag.parameters.count == 2,
+              let prefix = tag.parameters[0].string,
+              let suffix = tag.parameters[1].string
+        else {
+            throw Abort(.internalServerError, reason: "Wrong parameters count")
+        }
+        
+        let canonical = "<link rel=\"canonical\" href=\"\(prefix)\(locale)\(suffix)\" />\n"
+        
+        let alternates = try lingo.dataSource.availableLocales().map { alternate in
+            "<link rel=\"alternate\" hreflang=\"\(alternate)\" href=\"\(prefix)\(alternate)\(suffix)\" />\n"
+        }
+        
+        return LeafData.string(canonical + alternates.joined())
+    }
+}

--- a/Sources/LingoVaporLeaf/LocaleTag.swift
+++ b/Sources/LingoVaporLeaf/LocaleTag.swift
@@ -1,0 +1,13 @@
+import Vapor
+import Leaf
+import LingoVapor
+
+public final class LocaleTag: LeafTag {
+    public init() {}
+    public func render(_ tag: LeafContext) throws -> LeafData {
+        guard let lingo = try tag.application?.lingoVapor.lingo() else {
+            throw Abort(.internalServerError, reason: "Unable to get Lingo instance")
+        }
+        return LeafData.string(tag.request?.locale ?? lingo.defaultLocale)
+    }
+}

--- a/Sources/LingoVaporLeaf/LocalizeTag.swift
+++ b/Sources/LingoVaporLeaf/LocalizeTag.swift
@@ -26,4 +26,4 @@ public final class LocalizeTag: LeafTag {
             return .string(lingo.localize(key, locale: locale))
         }
     }
- }
+}


### PR DESCRIPTION
Changes proposed in this pull request:

# Tags
## LocaleTag

This tag allows to print the current locale in Leaf template.
Motivation: for SEO, it's useful to add a lang attribute to html tag. With this change, it can be implemented like this:
```html
<html lang="#locale()">
```
Also, it can be used in links to add the current locale:
```html
<a href="/#locale()/home" class="nav-link">#localize("home_title")</a>
```

## LocaleLinksTag

This tag is also for SEO, to generate canonical and alternates link tags.

```html
#localeLinks("https://www.latexcards.app/", "/home/")
```
Will give this for a user visiting homepage in french: (with `en` and `fr` as available locales)
```html
<link rel="canonical" href="https://www.latexcards.app/fr/home/" />
<link rel="alternate" hreflang="en" href="https://www.latexcards.app/en/home/" />
<link rel="alternate" hreflang="fr" href="https://www.latexcards.app/fr/home/" />
```

# Middlewares
## LocaleRedirectMiddleware

This one is also an improvement about SEO. It allows to serve different locales for each subfolders (it is linked to the example given for `LocaleLinksTag`).
By adding this middleware, the following behaviours are expected:
- if the user loads a page without locale specified in the URL, he is redirected to the same url but with the locale prefix, detected from browser preferences.
- if the user loads a page with a locale parameter, the page is shown in the queried language.

The setup is the following:

Add in `configure.swift`:
```swift
import LingoVapor

// Inside `configure(_ app: Application)`:
app.middleware.use(LocaleRedirectMiddleware())
```

Add in `routes.swift`:
```swift
import LingoVapor

// Inside `routes(_ app: Application)`:
app.get("home") { /* ... */ }
app.get(":locale", "home") { /* ... */ } // For each route, add the one prefixed by the `locale` parameter
```

That way, going to `/home/` will redirect you to `/<locale>/home/` (with `<locale>` corresponding to your browser locale), and going to `/fr/home/` will display homepage in french whatever the browser locale is.
