### PR TITLE
Using application's workingDirectory

### DIFF
--- a/Sources/LingoVapor/LingoProvider.swift
+++ b/Sources/LingoVapor/LingoProvider.swift
@@ -15,7 +15,7 @@ public struct LingoProvider {
     }
     
     public func lingo() throws -> Lingo {
-        let directory = DirectoryConfiguration.detect().workingDirectory
+        let directory = application.directory.workingDirectory
         let workDir = directory.hasSuffix("/") ? directory : directory + "/"
         let rootPath = workDir + (configuration?.localizationsDir ?? "")
         return try Lingo(rootPath: rootPath, defaultLocale: (configuration?.defaultLocale ?? ""))


### PR DESCRIPTION
LingoVapor was detecting the default working directory. I replaced it by the application working directory. (which is the same if default settings are left, or is the custom value if it is customized like in #11)

Fixes #11 